### PR TITLE
Fails when expecting Array, but got "0" value

### DIFF
--- a/src/tag-names-0th-ifd.js
+++ b/src/tag-names-0th-ifd.js
@@ -81,7 +81,7 @@ export default {
     0x0214: 'ReferenceBlackWhite',
     0x8298: {
         name: 'Copyright',
-        description: (value) => value.join('; ')
+        description: (value) => value instanceof Array ? value.join('; ') : value
     },
     0x8769: 'Exif IFD Pointer',
     0x8825: 'GPS Info IFD Pointer'

--- a/src/tags.js
+++ b/src/tags.js
@@ -103,7 +103,7 @@ function readTag(dataView, ifdType, tiffHeaderOffset, offset, byteOrder) {
         tagValue = getTagValue(dataView, tiffHeaderOffset + tagValueOffset, tagType, tagCount, byteOrder);
     }
 
-    if (tagType === Types.tagTypes['ASCII']) {
+    if (tagValue instanceof Array && tagType === Types.tagTypes['ASCII']) {
         tagValue = splitNullSeparatedAsciiString(tagValue);
     }
 


### PR DESCRIPTION
I have multiple images from a Canon 700D that have `0`-value on some of the tags that expects a string. It errors out on these values, although the rest of the tags are like expected.
For me the tags `Artist` and `Copyright` had a value of `0`. Where other correct tags had a string that got passed back as a array of characters.

Don't know if any of the tests should be edited, so let me know.