### PR TITLE
Handle Electron

### DIFF
--- a/examples/nodejs/exif.js
+++ b/examples/nodejs/exif.js
@@ -2,8 +2,8 @@
 
 const path = require('path');
 const fs = require('fs');
-global.DataView = require('jdataview');
-global.DOMParser = require('xmldom').DOMParser;
+global.DataView = global.DataView || require('jdataview');
+global.DOMParser = global.DOMParser || require('xmldom').DOMParser;
 
 const ExifReader = require('../../dist/exif-reader');
 
@@ -21,7 +21,7 @@ fs.readFile(filePath, function (error, data) {
     }
 
     try {
-        const tags = ExifReader.load(data);
+        const tags = ExifReader.load(data.buffer);
 
         // The MakerNote tag can be really large. Remove it to lower memory
         // usage if you're parsing a lot of files and saving the tags.


### PR DESCRIPTION
Electron exposes most of the node.js APIs like `fs`.
Electron also already has DataView built in.

*  A real `DataView` does not take a `Buffer`. That's a JDataView only thing

   Fortunately `Buffer`'s `buffer` property is a `Uint8Array` which
   is compatible with both `DataView` and `jDataView`.

*  You can't just replace the real `DataView` with `jDataView` because
   it breaks when trying to pass it an `ArrayBuffer`. I tried to get
   the owner accept a PR to fix it but he says replacing the built in
   one as done here is bad.

*  Node 6.x has `DataView` built in. No reason to replace it with `jDataView`

Of course maybe you'd like to make a separate folder for electron example but this example should work in both

#24 