### PR TITLE
jsnext:main lets rollup include as import * as ExifReader

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "bugs": "https://github.com/mattiasw/ExifReader/issues",
   "license": "LGPL-3.0",
   "main": "dist/exif-reader.js",
-  "jsnext:main": "src/exif-reader.js",
+  "module": "src/exif-reader.js",
   "devDependencies": {
     "babel-core": "^6.17.0",
     "babel-loader": "^6.2.8",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "bugs": "https://github.com/mattiasw/ExifReader/issues",
   "license": "LGPL-3.0",
   "main": "dist/exif-reader.js",
+  "jsnext:main": "src/exif-reader.js",
   "devDependencies": {
     "babel-core": "^6.17.0",
     "babel-loader": "^6.2.8",


### PR DESCRIPTION
This makes it compatible with rollup build system that I'm using.

Without, it wants to import at ./dist which doesn't seem to work