### PR TITLE
Parse GPS coordinates to float before passing back

### DIFF
--- a/src/tag-names-gps-ifd.js
+++ b/src/tag-names-gps-ifd.js
@@ -25,7 +25,7 @@ export default {
     0x0002: {
         'name': 'GPSLatitude',
         'description': (value) => {
-            return value[0] + value[1] / 60 + value[2] / 3600;
+            return parseFloat(value[0] + value[1] / 60 + value[2] / 3600);
         }
     },
     0x0003: {
@@ -43,7 +43,7 @@ export default {
     0x0004: {
         'name': 'GPSLongitude',
         'description': (value) => {
-            return value[0] + value[1] / 60 + value[2] / 3600;
+            return parseFloat(value[0] + value[1] / 60 + value[2] / 3600);
         }
     },
     0x0005: {


### PR DESCRIPTION
Parse result to float to check result elsewhere; can use isNaN on return value to see if you are suppose to get a number from a tag.

Shouldn't do anything but get rid of non floats. Need to add a test for xmp to get NaN due to funny GPS coords observed in #27, might be good elsewhere you expect floats. I would do the same for parseInt, then your tags that expect numbers should always return numbers.

Downside is having to deal with NaN