### PR TITLE
Relax dependency on @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "exif-reader.d.ts"
   ],
   "dependencies": {
-    "@types/node": "^10.12.18",
+    "@types/node": "*",
     "xmldom": "^0.1.27"
   },
   "types": "./exif-reader.d.ts",


### PR DESCRIPTION
The `@types/node` dependency was limited to a very specific version of node.

Generally, the node types should be provided by the actual execution environment, and any constraints should match those of the `engine` constraints in the `package.json` (there are one here).

This resolves TS errors for duplicate declarations when using more modern versions of node and TS.

### Description

<!-- Describe what the change does and why it's needed. If it's related to an issue, link to it. -->
