### PR TITLE
Move @types/node to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "exif-reader.d.ts"
   ],
   "dependencies": {
-    "@types/node": "^10.12.18",
     "xmldom": "^0.1.27"
   },
   "types": "./exif-reader.d.ts",
@@ -38,6 +37,9 @@
     "nyc": "^14.1.1",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.3.6"
+  },
+  "peerDependencies": {
+    "@types/node": "*"
   },
   "scripts": {
     "build": "webpack",


### PR DESCRIPTION
### Description

This is a follow-up to #60 that I was watching.

Alternatively, this moves `@types/node` to [`peerDependencies`](https://npm.github.io/using-pkgs-docs/package-json/types/peerdependencies.html) and in the process the obligation to install it to the project, with users getting only a peer dependency notice, e.g.

```
warning exifreader@x.y.z has unmet peer dependency "@types/node@*"
```

> Does `@types/node` have to be the specific version for the node version used?

No. The definition of `Buffer` has, to my knowledge, always been in `@types/node`.


