### PR TITLE
Updating the Keywords section as Array of NumberArrayTag 

### DIFF
--- a/exif-reader.d.ts
+++ b/exif-reader.d.ts
@@ -215,7 +215,7 @@ interface Tags {
     'Category': NumberArrayTag, // StringTag
     'Supplemental Category': NumberArrayTag, // StringTag
     'Fixture Identifier': NumberArrayTag, // StringTag
-    'Keywords': NumberArrayTag, // StringTag
+    'Keywords': NumberArrayTag[], // StringTag
     'Content Location Code': NumberArrayTag, // StringTag
     'Content Location Name': NumberArrayTag, // StringTag
     'Release Date': NumberArrayTag, // StringTag


### PR DESCRIPTION
As per the issue mentioned in the #105 

Updating the Keywords section as an Array of `NumberArrayTag` instead of `NumberArrayTag` which causes issues with Autocomplete, linting, and compiling.
This should fix the issue.

### Description

<!-- Describe what the change does and why it's needed. If it's related to an issue, link to it. -->
