### PR TITLE
Added DocumentName to interface Tags in TS type definitions

### DIFF
--- a/exif-reader.d.ts
+++ b/exif-reader.d.ts
@@ -143,6 +143,7 @@ interface Tags {
     'BitsPerSample': NumberArrayTag,
     'Compression': NumberTag,
     'PhotometricInterpretation': NumberTag,
+    'DocumentName': StringArrayTag,
     'ImageDescription': StringArrayTag,
     'Make': StringArrayTag,
     'Model': StringArrayTag,


### PR DESCRIPTION
I tried to read the DocumentName from a photo that has it in EXIF data and TS was complaining that there is no such property on the exif object. I added ts-ignore and happily read it. I therefore believe it was just missing in the d.ts file.