### PR TITLE
Add lens make and model to TS

### DIFF
--- a/exif-reader.d.ts
+++ b/exif-reader.d.ts
@@ -263,6 +263,8 @@ interface Tags {
     'DeviceSettingDescription'?: NumberTag & NumberArrayTag,
     'SubjectDistanceRange'?: NumberTag,
     'ImageUniqueID'?: StringArrayTag,
+    'LensMake'?: StringArrayTag,
+    'LensModel'?: StringArrayTag,
 
     // GPS tags
     'GPSVersionID'?: NumberTag,


### PR DESCRIPTION
Minor change to the TypeScript definition adding the `LensModel` and `LensMake` tags.