### PR TITLE
Fix XmpTag type

### DIFF
--- a/exif-reader.d.ts
+++ b/exif-reader.d.ts
@@ -93,7 +93,7 @@ interface StringArrayTag {
 }
 
 interface XmpTag {
-    value: string & Array<XmpTag> & XmpTags,
+    value: string | Array<XmpTag> | XmpTags,
     attributes: {
         [name: string]: string
     },


### PR DESCRIPTION
### Description
Hi,

I changed XmpTag['value'] type from intersection types to union types.
It is the expected behavior to be one of the types.

Current behavior
![Screen Shot 2022-07-04 at 18 42 15](https://user-images.githubusercontent.com/38808706/177129561-fbd11227-196a-4e2d-a58f-32d558d9dfed.png)

Expected behavior
![Screen Shot 2022-07-04 at 18 43 24](https://user-images.githubusercontent.com/38808706/177129655-6d23fa53-8276-43a1-9cf0-362efc717989.png)

