### PR TITLE
Add XMP raw string type to ExpandedTags["xmp"] type

### DIFF
--- a/exif-reader.d.ts
+++ b/exif-reader.d.ts
@@ -131,7 +131,7 @@ interface ExpandedTags {
     pngFile?: PngFileTags,
     exif?: Tags,
     iptc?: Tags,
-    xmp?: XmpTags,
+    xmp?: { _raw: string } & XmpTags,
     icc?: IccTags,
     Thumbnail?: ThumbnailTags,
     gps?: GpsTags


### PR DESCRIPTION
### Description
Fix  `tags.xmp._raw` type to string.
 Related to https://github.com/mattiasw/ExifReader/pull/183

Current behavior
<img width="644" alt="Screen Shot 2022-07-05 at 21 38 18" src="https://user-images.githubusercontent.com/38808706/177329241-7509fa2c-b2ad-4420-8af5-341708d31009.png">

Expected  behavior
<img width="622" alt="Screen Shot 2022-07-05 at 21 37 47" src="https://user-images.githubusercontent.com/38808706/177329290-0dd2e4d4-02d3-479e-bae6-ea223ef64d4e.png">

