### PR TITLE
Add missing file for replacing custom build constants

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -81,7 +81,7 @@ module.exports = {
                 }
             },
             {
-                test: /\/(exif-reader|image-header-?(tiff|jpeg|png|heic|webp)?|tag-names)\.js$/,
+                test: /\/(exif-reader|image-header-?(tiff|jpeg|png|heic|webp)?|tags|tag-names)\.js$/,
                 loader: 'string-replace-loader',
                 options: {
                     multiple: getConstantReplacements(includedModules)


### PR DESCRIPTION
tags.js use Constants.USE_THUMBNAIL but wasn't searched while replacing.

#248