### PR TITLE
Ensure accurate JPEG offset retrieval by accounting for the length of SOF marker segments

### DIFF
--- a/src/image-header-jpeg.js
+++ b/src/image-header-jpeg.js
@@ -71,8 +71,10 @@ function findJpegOffsets(dataView) {
 
     while (appMarkerPosition + APP_ID_OFFSET + 5 <= dataView.byteLength) {
         if (Constants.USE_FILE && isSOF0Marker(dataView, appMarkerPosition)) {
+            fieldLength = dataView.getUint16(appMarkerPosition + APP_MARKER_SIZE);
             sof0DataOffset = appMarkerPosition + APP_MARKER_SIZE;
         } else if (Constants.USE_FILE && isSOF2Marker(dataView, appMarkerPosition)) {
+            fieldLength = dataView.getUint16(appMarkerPosition + APP_MARKER_SIZE);
             sof2DataOffset = appMarkerPosition + APP_MARKER_SIZE;
         } else if (Constants.USE_JFIF && isApp0JfifMarker(dataView, appMarkerPosition)) {
             fieldLength = dataView.getUint16(appMarkerPosition + APP_MARKER_SIZE);


### PR DESCRIPTION
JPEG images can include additional marker segments after SOF marker segments. ExifReader failed to detect these because it did not account for the length of SOF marker segments.

Here is the binary representation of such an image:

![Screenshot 2024-03-08 at 13 49 57](https://github.com/mattiasw/ExifReader/assets/4021583/a1e84883-429b-4619-9872-5edca6a39dca)

I highlighted the markers with red.

- Byte 216: SOF2
- Byte 235: DHT
- Byte 264: DHT
- Byte 291: IPTC

Because ExifReader did not reassign the `fieldLength` for SOF segments, it reapplied the length of the previous marker segment. As a result, `appMarkerPosition` was out of sync and did not detect the following marker segments.