### PR TITLE
fix: no index signature with a parameter of type 'string' was found on type 'ExpandedTags'

### DIFF
--- a/exif-reader.d.ts
+++ b/exif-reader.d.ts
@@ -207,6 +207,7 @@ export interface ExpandedTags {
     Thumbnail?: ThumbnailTags,
     gps?: GpsTags
     photoshop?: PhotoshopTags;
+    [name: string]: any
 }
 
 interface GpsTags {


### PR DESCRIPTION
This is something that i had to add to stop complaining from compiler on my code:

```ts
import type {ExpandedTags} from "exifreader";
import DataTable from "primevue/datatable";
import Column from "primevue/column";
import {ref} from "vue";

const props = defineProps<{ metadata: ExpandedTags }>()
const nodes = ref<any[]>([])
const expandedRowGroups = ref();
Object.keys(props.metadata).forEach((header, headerIndex) => {
  Object.keys(props.metadata?.[header]).forEach((tag, tagIndex) => {
    const node = {
      key: `${headerIndex}-${tagIndex}`,
      header: header,
      tag: tag,
      value: props.metadata?.[header]?.[tag]?.description || props.metadata?.[header]?.[tag] || ""
    }
    nodes.value.push(node)
  })
})
```

The error was:
```
Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'ExpandedTags'.
  No index signature with a parameter of type 'string' was found on type 'ExpandedTags'.

16       value: props.metadata?.[header]?.[tag]?.description || props.metadata?.[header]?.[tag] || ""
```

I'm not sure, but perhaps the same thing should be added to every interface containing string keys.