### PR TITLE
Round aperture value to 1 decimal point

### DIFF
--- a/src/tag-names-common.js
+++ b/src/tag-names-common.js
@@ -94,7 +94,7 @@ export default {
         }
         return `0/${value[1]}`;
     },
-    FNumber: (value) => `f/${value[0] / value[1]}`,
+    FNumber: (value) => `f/${Number(value[0] / value[1]).toFixed(1)}`,
     FocalLength: (value) => (value[0] / value[1]) + ' mm',
     FocalPlaneResolutionUnit(value) {
         if (value === 2) {


### PR DESCRIPTION
### Description

Sometimes the aperture value is reported as `f/5.599999904632568` which isn't very user-friendly

Before:
`f/5.599999904632568`
After:
`f/5.6`
