### PR TITLE
Add cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 2
     groups:
       dev-dependencies:
         dependency-type: "development"


### PR DESCRIPTION
## Summary
- add a two-day cooldown to the npm update configuration so Dependabot ignores very new releases

## Testing
- npm-run-all lint test:types coverage test:build

------
https://chatgpt.com/codex/tasks/task_e_68cd993bf0c883289ede56418252893c