### PR TITLE
Restore side-effect-free tree-shaking of the src modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Custom builds no longer include the modules that were excluded from them,
+  and consumer bundlers can again tree-shake the source modules. A regression
+  in 4.41.1 made the new `src/package.json` hide the root `sideEffects`
+  declaration from bundlers, which roughly doubled the size of custom builds.
+
 ## [4.41.2] - 2026-07-18
 
 ### Fixed

--- a/src/package.json
+++ b/src/package.json
@@ -1,1 +1,1 @@
-{"type": "module"}
+{"type": "module", "sideEffects": false}

--- a/test/build/custom-builds.json
+++ b/test/build/custom-builds.json
@@ -190,7 +190,8 @@
             "include": {
                 "gif": true
             }
-        }
+        },
+        "maxDistRatio": 0.3
     },
     {
         "id": "tiff-png",

--- a/test/build/packaging.js
+++ b/test/build/packaging.js
@@ -38,9 +38,9 @@ describe('packaging', function () {
         }
     });
 
-    it('declares src as ES modules and nothing else', () => {
+    it('declares src as side-effect-free ES modules and nothing else', () => {
         const content = JSON.parse(fs.readFileSync(path.join(ROOT_PATH, 'src', 'package.json'), 'utf8'));
-        expect(content).to.deep.equal({type: 'module'});
+        expect(content).to.deep.equal({type: 'module', sideEffects: false});
     });
 
     it('resolves require of the package root to the UMD bundle', () => {

--- a/test/build/test-custom.js
+++ b/test/build/test-custom.js
@@ -34,6 +34,17 @@ describe('custom configuration image outputs', () => {
                     cleanUp();
                 });
 
+                if (configuration.maxDistRatio) {
+                    // Guards module elimination: the parse-output comparison
+                    // below passes even when tree-shaking is broken and the
+                    // bundle ships every module (regression in 4.41.1).
+                    it('stays substantially smaller than the full bundle', () => {
+                        const customSize = fs.statSync(path.join(TEMP_PROJECT_DIR, 'node_modules', 'exifreader', 'dist', 'exif-reader.js')).size;
+                        const fullSize = fs.statSync(path.join(__dirname, '..', '..', 'dist', 'exif-reader.js')).size;
+                        expect(customSize).to.be.below(fullSize * configuration.maxDistRatio);
+                    });
+                }
+
                 fs.readdirSync(path.join(FIXTURES_PATH, 'images')).forEach((imageName) => {
                     it(`matches stored image output for ${imageName}`, async () => {
                         await testFile(imageName, configuration);


### PR DESCRIPTION
The src/package.json added in 4.41.1 for native ESM shadowed the root
package.json's sideEffects declaration, so webpack kept unreferenced
modules and custom builds came out roughly twice their intended size.
Declare sideEffects in src/package.json too, and add a bundle-size guard
to the custom-build suite since the parse-output comparison alone cannot
catch a bloated but functionally correct bundle.